### PR TITLE
Fix Showing Git Status in Airline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,9 +67,6 @@
 [submodule ".vim/pack/plugins/opt/vim-docker-tools"]
 	path = tilde/.vim/pack/plugins/opt/vim-docker-tools
 	url = https://github.com/kevinhui/vim-docker-tools.git
-[submodule ".vim/pack/plugins/start/match-count-statusline"]
-	path = tilde/.vim/pack/plugins/start/match-count-statusline
-	url = https://github.com/emilyst/match-count-statusline.git
 [submodule ".vim/pack/plugins/opt/ansible-vim"]
 	path = tilde/.vim/pack/plugins/opt/ansible-vim
 	url = https://github.com/pearofducks/ansible-vim.git

--- a/tilde/.vim/plugin/airline-configuration.vim
+++ b/tilde/.vim/plugin/airline-configuration.vim
@@ -2,46 +2,50 @@
 
 " === CONFIGURATION ===
 let g:airline_theme                      = 'solarized'
-let g:airline_powerline_fonts            = '1'
+let g:airline_powerline_fonts            = 1
+let g:airline_skip_empty_sections        = 0
+
 let g:airline#extensions#branch#enabled  = '1'
-let g:airline_skip_empty_sections = 1
+let g:airline#extensions#branch#format   = '2'
+let g:airline#extensions#branch#empty_message = 'BRANCH NOT FOUND'
 
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#formatter = 'unique_tail_improved'
 
+" ===== FUTURE IDEAS =====
 " I don't like the basic Obsession extention, lets make it better...
-let g:airline#extensions#obsession#enabled = 0
-
+"let g:airline#extensions#obsession#enabled = 0
 " ... by building the whole status line ourselves.
-function! CustomStatusline(...)
-    " first variable is the statusline builder
-    let builder = a:1
-
-    " Since we only want add a section, get the default sections definitions
-    let l:airline_section_a  = g:airline_section_a
-    let l:airline_section_b  = get(w:, 'airline_section_b', g:airline_section_b)
-    let l:airline_section_c  = get(w:, 'airline_section_c', g:airline_section_c)
-    let l:airline_section_x  = get(w:, 'airline_section_x', g:airline_section_x)
-    let l:airline_section_y  = get(w:, 'airline_section_y', g:airline_section_y)
-    let l:airline_section_z  = get(w:, 'airline_section_y', g:airline_section_z)
-
-    call builder.add_section('airline_a', l:airline_section_a)
-    call builder.add_section('airline_b', l:airline_section_b)
-    call builder.add_section('airline_c', l:airline_section_c)
-    call builder.split()
-    call builder.add_section('airline_x', l:airline_section_x)
-    call builder.add_section('airline_z', 'Obsessed')
-    call builder.add_section('airline_y', l:airline_section_y)
-    call builder.add_section('airline_z', l:airline_section_z)
-
-    " tell the core to use the contents of the builder
-    return 1
-endfunction
+"function! CustomStatusline(...)
+"    " first variable is the statusline builder
+"    let builder = a:1
+"
+"    " Since we only want add a section, get the default sections definitions
+"    let l:airline_section_a  = g:airline_section_a
+"    let l:airline_section_b  = get(w:, 'airline_section_b', g:airline_section_b)
+"    let l:airline_section_c  = get(w:, 'airline_section_c', g:airline_section_c)
+"    let l:airline_section_x  = get(w:, 'airline_section_x', g:airline_section_x)
+"    let l:airline_section_y  = get(w:, 'airline_section_y', g:airline_section_y)
+"    let l:airline_section_z  = get(w:, 'airline_section_y', g:airline_section_z)
+"
+"    call builder.add_section('airline_a', l:airline_section_a)
+"    call builder.add_section('airline_b', l:airline_section_b)
+"    call builder.add_section('airline_c', l:airline_section_c)
+"    call builder.split()
+"    call builder.add_section('airline_x', l:airline_section_x)
+"    call builder.add_section('airline_z', 'Obsessed')
+"    call builder.add_section('airline_y', l:airline_section_y)
+"    call builder.add_section('airline_z', l:airline_section_z)
+"
+"    " tell the core to use the contents of the builder
+"    return 1
+"endfunction
 " ... Or we would if we could. The statusline builder is kinda broken right
 " now, and the status line doesn't behave as expected when changing to the
 " command mode, or displaying nicely padded text for that matter. Keeping the
 " above here in case it's all fixed one day.
 " call airline#add_statusline_func('CustomStatusline')
+
 "let g:airline#extensions#obsession#enabled = 1
 "let g:airline#extensions#obsession#indicator_text = " Obsessed "
 


### PR DESCRIPTION
I've been having issues with the branch and git status being displayed
in my status line, and it turns out that the match-count-statusline
plugin was hard overwriting the airline_section_b variable, which made
it so that the git status could not be displayed.

I could write a custom after directory vim file to fix this, but I'm a
little too lazy, and I'm not that heartbroken about losing this one
plugin.