### PR TITLE
Set termguicolors in vim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
 [submodule "tilde/.vim/pack/plugins/start/animate.vim"]
 	path = tilde/.vim/pack/plugins/start/animate.vim
 	url = https://github.com/camspiers/animate.vim.git
+[submodule "tilde/.vim/pack/colors/opt/NeoSolarized"]
+	path = tilde/.vim/pack/colors/opt/NeoSolarized
+	url = https://github.com/icymind/NeoSolarized.git

--- a/homemaker.toml
+++ b/homemaker.toml
@@ -11,6 +11,7 @@
         [".hammerspoon"],
         [".mytop"],
         [".psqlrc"],
+        [".terminfo"],
         [".tmux.conf"],
         [".vim"],
         [".vimrc"],
@@ -70,6 +71,13 @@
     cmds = [
         ["curl", "-L", "//iterm2.com/shell_integration/install_shell_integration_and_utilities.sh", "|", "bash"],
         ["rm -f", "~/.iterm_shell_integration.fish"],
+    ]
+[tasks.terminfo]
+    accepts = ["which", "tic"]
+    cmds = [
+        ["tic", "-o", "$HOME/terminfo","tmux.terminfo"],
+        ["tic", "-o", "$HOME/terminfo","tmux-256color.terminfo"],
+        ["tic", "-o", "$HOME/terminfo","xterm-256color.terminfo"],
     ]
 
 # ========================================================================= }}}

--- a/tilde/.vim/plugin/gitgutter-configuration.vim
+++ b/tilde/.vim/plugin/gitgutter-configuration.vim
@@ -6,6 +6,8 @@ let g:gitgutter_map_keys = 0
 let g:gitgutter_realtime = 1
 let g:gitgutter_eager = 1
 
+let g:gitgutter_override_sign_column_highlight = 0
+
 let g:gitgutter_sign_added = '+'
 let g:gitgutter_sign_modified = '~'
 let g:gitgutter_sign_removed = '-'

--- a/tilde/.vimrc
+++ b/tilde/.vimrc
@@ -60,16 +60,21 @@ set hlsearch
 function! MyHighlights() abort
     " https://gist.github.com/romainl/379904f91fa40533175dfaec4c833f2f
     " Only highlight the 81st character when it's visable on the screen.
-    highlight ColorColumn ctermbg=170 ctermfg=234
+    highlight ColorColumn guibg=#e75480 guifg=#FFFFFF
     call matchadd('ColorColumn', '\%81v', 100)
 
     " Other highlights
-    highlight PmenuSel ctermbg=15 ctermfg=197
-    highlight Pmenu ctermbg=15 ctermfg=217
+    highlight PmenuSel cterm=bold guifg=#ffb6c1 guibg=#e75480
+    highlight Pmenu cterm=none guifg=#e75480 guibg=#ffb6c1
     highlight SearchHighlight ctermfg=3
     highlight SpellBad ctermbg=7 ctermfg=none
-    highlight CursorLineNR cterm=bold ctermfg=3 ctermbg=0
-    highlight CursorLine cterm=none ctermbg=0 ctermfg=NONE
+    highlight CursorLineNR cterm=bold guifg=#b58900
+    highlight CursorLine cterm=none ctermbg=0 ctermfg=none
+    highlight SignColumn guibg=#073642
+
+    highlight GitGutterAdd    guifg=#859900 guibg=#073642
+    highlight GitGutterChange guifg=#b58900 guibg=#073642
+    highlight GitGutterDelete guifg=#dc322f guibg=#073642
 endfunction
 
 augroup MyColors
@@ -78,7 +83,11 @@ augroup MyColors
 augroup END
 
 set termguicolors
-colorscheme solarized8_flat
+
+let g:neosolarized_vertSplitBgTrans = 0
+let g:neosolarized_italic = 1
+let g:neosolarized_termBoldAsBright = 0
+colorscheme NeoSolarized
 
 if has('termguicolors') && $COLORTERM ==? 'truecolor'
     let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
@@ -372,8 +381,8 @@ if has('autocmd')
     augroup vimrcAutoView
         autocmd!
         " Autosave & Load Views.
-        autocmd BufWritePost,BufLeave ?* if MakeViewCheck() | silent! mkview | endif
-        autocmd BufWinEnter ?* if MakeViewCheck() | silent! loadview | endif
+        autocmd BufWritePost,BufLeave ?* nested if MakeViewCheck() | silent! mkview | endif
+        autocmd BufWinEnter ?* nested if MakeViewCheck() | silent! loadview | endif
     augroup end
 endif
 


### PR DESCRIPTION
After spending years resisting it, I have finally upgraded to a more
modern Solarized implementation. This ended up being more work than I
expected since I had to change the way I was doing a lot of my custom
highlighting.

Now instead of using `ctermfg` and `ctermbg` for most things, I have to
use their `gui` counterparts and hex codes. This is actually _really_
nice since I now get to pick more accurate colors!