### PR TITLE
Fixing Prompt Color Redrawing

### DIFF
--- a/tilde/.config/fish/functions/iterm_shell_integration.fish
+++ b/tilde/.config/fish/functions/iterm_shell_integration.fish
@@ -1,17 +1,3 @@
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
 if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ "$ITERM_ENABLE_SHELL_INTEGRATION_WITH_TMUX""$TERM" != screen ]; and [ "$TERM" != dumb ]; and [ "$TERM" != linux ]; end
   function iterm2_status
     printf "\033]133;D;%s\007" $argv
@@ -27,55 +13,8 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
     printf "\033]133;B\007"
   end
 
-  # Tell terminal to create a mark at this location
-  function iterm2_preexec --on-event fish_preexec
-    # For other shells we would output status here but we can't do that in fish.
-    printf "\033]133;C;\007"
-  end
-
-  # Usage: iterm2_set_user_var key value
-  # These variables show up in badges (and later in other places). For example
-  # iterm2_set_user_var currentDirectory "$PWD"
-  # Gives a variable accessible in a badge by \(user.currentDirectory)
-  # Calls to this go in iterm2_print_user_vars.
-  function iterm2_set_user_var
-    printf "\033]1337;SetUserVar=%s=%s\007" "$argv[1]" (printf "%s" "$argv[2]" | base64 | tr -d "\n")
-  end
-
   function iterm2_write_remotehost_currentdir_uservars
     printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=%s\007" $USER $iterm2_hostname $PWD
-
-    # Users can define a function called iterm2_print_user_vars.
-    # It should call iterm2_set_user_var and produce no other output.
-    if functions -q -- iterm2_print_user_vars
-      iterm2_print_user_vars
-    end
-
-  end
-
-  functions -c fish_prompt iterm2_fish_prompt
-
-  functions -c fish_mode_prompt iterm2_fish_mode_prompt
-  function fish_mode_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
-     set -l last_status $status
-
-     iterm2_status $last_status
-     iterm2_write_remotehost_currentdir_uservars
-     if not functions iterm2_fish_prompt | grep iterm2_prompt_mark > /dev/null
-         iterm2_prompt_mark
-     end
-     sh -c "exit $last_status"
-
-     iterm2_fish_mode_prompt
-  end
-
-  function fish_prompt --description 'Write out the prompt; do not replace this. Instead, change fish_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_prompt instead.'
-     # Remove the trailing newline from the original prompt. This is done
-     # using the string builtin from fish, but to make sure any escape codes
-     # are correctly interpreted, use %b for printf.
-     printf "%b" (string join "\n" (iterm2_fish_prompt))
-
-     iterm2_prompt_end
   end
 
   # If hostname -f is slow for you, set iterm2_hostname before sourcing this script
@@ -90,4 +29,5 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
   iterm2_write_remotehost_currentdir_uservars
   printf "\033]1337;ShellIntegrationVersion=10;shell=fish\007"
 end
+
 alias imgcat=~/.iterm2/imgcat;alias imgls=~/.iterm2/imgls;alias it2api=~/.iterm2/it2api;alias it2attention=~/.iterm2/it2attention;alias it2check=~/.iterm2/it2check;alias it2copy=~/.iterm2/it2copy;alias it2dl=~/.iterm2/it2dl;alias it2getvar=~/.iterm2/it2getvar;alias it2git=~/.iterm2/it2git;alias it2setcolor=~/.iterm2/it2setcolor;alias it2setkeylabel=~/.iterm2/it2setkeylabel;alias it2ul=~/.iterm2/it2ul;alias it2universion=~/.iterm2/it2universion

--- a/tilde/.config/fish/prompt/fish_prompt.fish
+++ b/tilde/.config/fish/prompt/fish_prompt.fish
@@ -1,4 +1,6 @@
 function fish_prompt --description 'Write out the prompt'
+    iterm2_prompt_mark
+
     __fish_prompt_in_docker #Check first to see if we're in a docker container
     __fish_prompt_username
     __fish_prompt_hostname
@@ -27,7 +29,8 @@ function fish_prompt --description 'Write out the prompt'
             set fish_color_prompt magenta --bold
     end
 
-    #set -l glyph "➜"
     set -l glyph "❯"
     echo -ns (set_color $fish_color_prompt) " $glyph " (set_color normal)
+
+    iterm2_prompt_end
 end


### PR DESCRIPTION
I had been having trouble for a while now that every time I would go
from normal to insert mode that my prompt wouldn't change color. I did
some digging and found out it was because the iTerm2 integrations were
overriding a lot of the fish prompt infrastructure. I've now ripped most
of that out and am just calling the functions I need in my own prompt.