### PR TITLE
Job and Screen Prompt

### DIFF
--- a/tilde/.config/fish/conf.d/aliases.fish
+++ b/tilde/.config/fish/conf.d/aliases.fish
@@ -29,6 +29,9 @@ if status --is-interactive
     # Misc
     abbr --add ag rg # some habits are too hard to break
 
+    # Terraform on M1
+    alias terraform-amd64="TF_DEMUX_ARCH=amd64 terraform-demux"
+
     # tmux
     abbr --add t tmux
     abbr --add tt tmux_for_ticket

--- a/tilde/.config/fish/prompt/prompt_functions/__fish_prompt_jobs.fish
+++ b/tilde/.config/fish/prompt/prompt_functions/__fish_prompt_jobs.fish
@@ -1,11 +1,8 @@
 function __fish_prompt_jobs --description 'Helper function for fish_prompt'
-    jobs | egrep -v 'autojump|-WINCH|*async*' >/dev/null 2>/dev/null; or return 0
-
-    set job_count (jobs | egrep -v 'autojump|__fish_prompt_git_status|-WINCH|__async|echo $vars' | wc -l)
-
-    set job_count (echo $job_count | sed -E "s/[[:space:]]+//g" )
-
-    if test "$job_count" != 0
-        echo -ns (set_color $fish_prompt_color_jobs) " $job_count"
+    set -l job_count (jobs | egrep -v 'autojump|__fish_prompt_git_status|-WINCH|__async|echo $vars' | sed "s/^[[:space:]].*//" | sed '/^$/d' | wc -l)
+    if test $job_count = 0
+        return
+    else
+        echo -ns (set_color $fish_prompt_color_jobs) " ﰌ " (set_color normal) $job_count (set_color normal)
     end
 end

--- a/tilde/.config/fish/prompt/prompt_functions/__fish_prompt_screen.fish
+++ b/tilde/.config/fish/prompt/prompt_functions/__fish_prompt_screen.fish
@@ -6,8 +6,8 @@ function __fish_prompt_screen --description 'Helper function for fish_prompt'
 
     set -l sty (echo $STY)
     if test -n "$sty"
-        echo -ns (set_color $fish_prompt_color_in_screen) "  $screen_count"
+        echo -ns (set_color $fish_prompt_color_in_screen) "  " (set_color normal) $screen_count (set_color normal)
     else
-        echo -ns (set_color $fish_prompt_color_screen) "  $screen_count"
+        echo -ns (set_color $fish_prompt_color_screen) "  " (set_color normal) $screen_count (set_color normal)
     end
 end

--- a/tilde/.gitconfig
+++ b/tilde/.gitconfig
@@ -71,7 +71,7 @@
 
 # Override settings when working on work-related projects
 # on a personal machine.
-[includeIf "gitdir:~dev/github.com/pelotoncycle/"]
+[includeIf "gitdir:~/dev/gitlab.com/replicant-ai/"]
 	path = ~/.gitconfig.work
 
 # Override machine-specific settings.


### PR DESCRIPTION
- Fixed how I calculate and display the number of jobs running in the background.
- Added a prompt feature to show the number of running screen sessions.

Other features:
- Using terraform-arm64 because of Apple M1.
- Fixed directory in .gitconfig for when `tilde/.gitconfig` is sourced.