### PR TITLE
Fixing `__fish_prompt_screen`

### DIFF
--- a/tilde/.config/fish/README.md
+++ b/tilde/.config/fish/README.md
@@ -4,10 +4,12 @@
     <img src="https://i.imgur.com/WidJ8uW.jpg">
 </p>
 
-Hello, and welcome to my overly complicated Fish config. This has been evolving over many years and it's now in a place where it's easily extensible and I'm very happy with it. Please see the individual sections below for more detail about how it all works.
+Hello, and welcome to my overly complicated Fish config. This has been evolving over the last 10 years and it's now in a place where I find it both extensible and performant. Please see the individual sections below for more detail about how it all works.
 
 ## Prompt
+
 ### Dynamic Elements
+
 The main aspect of my prompt is that it dynamically changes based on current conditions and folder contents. Out of the gate in my homedir it'll look pretty simplistic:
 ![](https://i.imgur.com/rrLsmoC.png)
 
@@ -23,23 +25,29 @@ After running a k8s command inside a directory with golang that has uncommitted 
 ![](https://i.imgur.com/VDGRoWi.png)
 
 ### Async Features
+
 The aspect of my prompt that I'm most proud of is making the longest running bits asynchronous. After originally creating this prompt I noticed that my `__fish_prompt_git_status` command would take a long time to return in directories with lots of submodules, see: this repo, and I knew that it wouldn't do. Since I was new to Fish I tried a lot of ideas that other people had offered, and none of them seemed to work until I found [@MaxMilton](https://github.com/MaxMilton) "Pure" Fish theme and it's async features. As of now my prompt will draw almost always in under 50ms and will load in elements as the finish processing.
 
 ### Auto `git fetch`
+
 Using the async features above I automatically `git fetch` if it's been more than 10 minutes since it's happened on any given repo. This works great with the `git status` party of my prompt as it'll display a `↓` symbol when I'm behind from origin.
 
 ## Functions
 
 ## Completions
+
 All of these completions are managed by homemaker and symlinked into the completions directory.
 
 ## Vim Integration
+
 Most of my day-to-day works occurs inside of Vim, so I thought I would make my terminal function like Vim as well. I have Fish's wonderful vi-mode turned on, as well as many aliases that'll open Vim on different conditions.
 
 ## FZF
+
 Since Fish does not have a built in history search function I've decided to use FZF's ctrl-r feature as a replacement.
 
 ## Greets
-* [@zgracem](https://github.com/zgracem) for the [modular prompt idea](https://github.com/zgracem/dotconfig/tree/master/fish). It changed the entire way of how I think about building a prompt!
-* [@MaxMilton](https://github.com/MaxMilton) for creating an [async prompt](https://github.com/MaxMilton/pure/blob/master/functions/__pure_run_async.fish) that works with my setup! I tried different configs for months before finding their ideas.
-* [@matchi](https://github.com/matchai) for creating [spacefish](https://github.com/matchai/spacefish) that inspired the look of my prompt, and some ideas around it's modularity.
+
+- [@zgracem](https://github.com/zgracem) for the [modular prompt idea](https://github.com/zgracem/dotconfig/tree/master/fish). It changed the entire way of how I think about building a prompt.
+- [@MaxMilton](https://github.com/MaxMilton) for creating an [async prompt](https://github.com/MaxMilton/pure/blob/master/functions/__pure_run_async.fish) that works with my setup. I tried different async methods for Fish prompt before finding one that works for me.
+- [@matchi](https://github.com/matchai) for creating [spacefish](https://github.com/matchai/spacefish) that inspired the look of my prompt, and it's ideas around modularity.

--- a/tilde/.config/fish/functions/fzf_key_bindings.fish
+++ b/tilde/.config/fish/functions/fzf_key_bindings.fish
@@ -1,1 +1,1 @@
-/opt/homebrew/opt/fzf/shell/key-bindings.fish
+/Users/patrickking/.local/share/nvim/plugged/fzf/shell/key-bindings.fish

--- a/tilde/.config/fish/prompt/prompt_functions/__fish_prompt_screen.fish
+++ b/tilde/.config/fish/prompt/prompt_functions/__fish_prompt_screen.fish
@@ -1,5 +1,7 @@
 function __fish_prompt_screen --description 'Helper function for fish_prompt'
-    set -l screen_count (screen -ls | egrep -v 'Socket|There is a screen|^[[:space:]]*$' | wc -l)
+    # Yes this grep could be nicer, but it's easier to just have both the
+    # single and plural options.
+    set -l screen_count (screen -ls | egrep -v 'Socket|Sockets|There is a screen|There are screens|^[[:space:]]*$' | wc -l)
     if test $screen_count = 0
         return
     end

--- a/tilde/.hammerspoon/system/networking.lua
+++ b/tilde/.hammerspoon/system/networking.lua
@@ -7,8 +7,6 @@ local phoneSSID = secrets.networking.phoneSSID
 local officeSSID = secrets.networking.officeSSID
 local lastSSID = "startup"
 
-proxyPid = nil
-
 function networking.networkReconnect(dns)
     -- Right after swapping interfaces the result can be nil. We want to retrun until it's not
     local defaultInterface = string.format("%s", hs.network.interfaceName(hs.network.primaryInterfaces()))
@@ -43,7 +41,7 @@ end
 local function phoneWifiConnected()
     hs.audiodevice.defaultOutputDevice():setVolume(0)
     networking.networkReconnect(secrets.networking.phoneDNS)
-    sleep(1)
+
     notification("Teathered to Phone", phone_logo)
     _log("Connected to home WiFi")
 end
@@ -158,38 +156,6 @@ function networking.disableWifiSlowly()
     hs.wifi.setPower(false)
     _log("Wifi disabled after being docked.")
 end
-
---TODO: refactor this to use `run.cmd` instead of `hs.execute`
---function networking.reconnectProxy()
---    _log("Reconnecting to proxy")
---
---    proxyPid = hs.execute("/usr/bin/pgrep autossh")
---
---    if proxyPid ~= "" then
---        hs.execute("/usr/bin/pgrep autossh | xargs /bin/kill -s SIGUSR1")
---        _log("SIGUSR1 sent to pid: " .. proxyPid .. " to restart proxy.")
---    elseif proxyPid == "" then
---        _log("No proxy running.")
---        _log("Killing off any errant autossh processes.")
---        hs.execute("killall autossh")
---
---        _log("Starting proxy.")
---        local conn = "localhost:" .. secrets.networking.proxyPort
---        local config = os.getenv("HOME") .. "/.ssh/config"
---        local args = {
---            "-M", "0", "-N", "-f", "-F", config, "-v", "-D", conn, "proxy"
---        }
---        local env = {AUTOSSH_DEBUG = "1", AUTOSSH_LOGFILE = "/tmp/autossh.log"}
---
---        local reconnect = hs.task.new("$brewbin/autossh",
---                                      executeHelpers.callback, args):waitUntilExit()
---        reconnect:setEnvironment(env)
---        reconnect:start()
---
---        proxyPid = reconnect:pid()
---        _log("Autossh started.")
---    end
---end
 
 function networking.init()
     local initStart = os.clock()


### PR DESCRIPTION
Previously `_fish_prompt_screen` would display the incorrect values when more than one screen was open.

## Other updates
- Small updates to my fish README.md
- Cleaning up networking.lua to remove unused functions
- Setting fish environment to use NVIM specific FZF prompt functions