### PR TITLE
Fish: Better --is-interactive

### DIFF
--- a/tilde/.config/fish/conf.d/aliases.fish
+++ b/tilde/.config/fish/conf.d/aliases.fish
@@ -1,78 +1,78 @@
-if status --is-interactive
-    set -g fish_user_abbreviations
+status --is-interactive
+or exit 0
 
-    # Moving around
-    alias ls='ls --color=auto'
-    alias l1="ls --color=auto -1"
-    alias more="less"
-    alias cd..="cd .."
-    alias cp="cp -i"
+set -g fish_user_abbreviations
 
-    function ll
-        pwd
-        ls --color=auto -laF $argv
-    end
+# Moving around
+alias ls='ls --color=auto'
+alias l1="ls --color=auto -1"
+alias more="less"
+alias cd..="cd .."
+alias cp="cp -i"
 
-    # Colorized and better syntax for diff.
-    alias diff='diff'
-
-    # Colorized grep
-    alias grep='grep --color=auto'
-
-    # COLORZ
-    alias less='less -R'
-
-    # Cleaner time output.
-    #alias time='time -f "\t%e real\t%U user\t%S sys\t%P CPU\t%x status"'
-
-    ### Abbreviations ###
-    # Misc
-    abbr --add ag rg # some habits are too hard to break
-    abbr --add hub gh # I always type `hub` instead of the newer `gh` command
-
-    # Terraform
-    abbr --add tf 'terraform fmt'
-    abbr --add tp 'terraform fmt && terraform plan'
-    abbr --add tgp 'terragrunt hclfmt && terragrunt plan'
-    abbr --add tgg 'terragrunt show'
-
-    # K8s
-    abbr --add k kubectl
-    abbr --add kctx kubectx
-
-    # History
-    abbr -a !! --position anywhere --function last_history_item
-
-    # tmux
-    abbr --add t tmux
-    abbr --add tt tmux_for_ticket
-    abbr --add tls 'tmux list-sessions'
-
-    # Sensu expansion
-    abbr --add silence '/nail/sys/bin/downtime (hostname --fqdn)'
-    abbr --add unsilence 'sensu-cli stash delete silence/(hostname --fqdn)'
-    abbr --add sreport /nail/sys/bin/sensu-report
-    abbr --add ssreport 'sensu-cli client delete (hostname --fqdn) ;and sleep 60 ;and sensu-report'
-    abbr --add cnfdiff 'git diff --no-index -- /etc/my.cnf /nail/etc/my.cnf'
-
-    # Git expansions
-    abbr --add gco 'git checkout'
-    abbr --add gcub 'git checkout -b u/(whoami)/'
-    abbr --add gpib 'git push origin HEAD:i/(whoami)/'
-    abbr --add gcam 'git commit -a -m'
-    abbr --add gs 'git status'
-    abbr --add gd 'git diff'
-    abbr --add gb 'git branch'
-    abbr --add ga 'git add'
-    abbr --add git-clean 'git pull ;and git remote prune origin ;and git gc'
-    abbr --add grh 'git reset --hard'
-    abbr --add gbf fuzzy_git_branch
-    abbr --add grd 'cd (git rev-parse --git-dir) ; cd ..'
-    abbr --add gpom --function git_pull_origin_default
-    abbr --add gcm --function git_checkout_default
-    abbr --add gdm --function git_diff_default
-
-    # `gpom`, `gdm`, and `gcm` are now set in:
-    # prompt/prompt_functions/__fish_prompt_git_checkout_default.fish
-
+function ll
+    pwd
+    ls --color=auto -laF $argv
 end
+
+# Colorized and better syntax for diff.
+alias diff='diff'
+
+# Colorized grep
+alias grep='grep --color=auto'
+
+# COLORZ
+alias less='less -R'
+
+# Cleaner time output.
+#alias time='time -f "\t%e real\t%U user\t%S sys\t%P CPU\t%x status"'
+
+### Abbreviations ###
+# Misc
+abbr --add ag rg # some habits are too hard to break
+abbr --add hub gh # I always type `hub` instead of the newer `gh` command
+
+# Terraform
+abbr --add tf 'terraform fmt'
+abbr --add tp 'terraform fmt && terraform plan'
+abbr --add tgp 'terragrunt hclfmt && terragrunt plan'
+abbr --add tgg 'terragrunt show'
+
+# K8s
+abbr --add k kubectl
+abbr --add kctx kubectx
+
+# History
+abbr -a !! --position anywhere --function last_history_item
+
+# tmux
+abbr --add t tmux
+abbr --add tt tmux_for_ticket
+abbr --add tls 'tmux list-sessions'
+
+# Sensu expansion
+abbr --add silence '/nail/sys/bin/downtime (hostname --fqdn)'
+abbr --add unsilence 'sensu-cli stash delete silence/(hostname --fqdn)'
+abbr --add sreport /nail/sys/bin/sensu-report
+abbr --add ssreport 'sensu-cli client delete (hostname --fqdn) ;and sleep 60 ;and sensu-report'
+abbr --add cnfdiff 'git diff --no-index -- /etc/my.cnf /nail/etc/my.cnf'
+
+# Git expansions
+abbr --add gco 'git checkout'
+abbr --add gcub 'git checkout -b u/(whoami)/'
+abbr --add gpib 'git push origin HEAD:i/(whoami)/'
+abbr --add gcam 'git commit -a -m'
+abbr --add gs 'git status'
+abbr --add gd 'git diff'
+abbr --add gb 'git branch'
+abbr --add ga 'git add'
+abbr --add git-clean 'git pull ;and git remote prune origin ;and git gc'
+abbr --add grh 'git reset --hard'
+abbr --add gbf fuzzy_git_branch
+abbr --add grd 'cd (git rev-parse --git-dir) ; cd ..'
+abbr --add gpom --function git_pull_origin_default
+abbr --add gcm --function git_checkout_default
+abbr --add gdm --function git_diff_default
+
+# `gpom`, `gdm`, and `gcm` are now set in:
+# prompt/prompt_functions/__fish_prompt_git_checkout_default.fish

--- a/tilde/.config/fish/conf.d/env.fish
+++ b/tilde/.config/fish/conf.d/env.fish
@@ -2,9 +2,9 @@
 # This is here because I will often want to get the brew prefix to check to see
 # if a file exists with something installed be brew. Calling `brew --prefix` is
 # slow, so I cache it here.
-if which brew >/dev/null
-    if not set -q __brew_prefix && $__brew_prefix == ""
-        set -U __brew_prefix (/opt/homebrew/bin/brew --prefix)
+if not set -q __brew_prefix && $__brew_prefix == ""
+    if set -lx __brew (which brew)
+        set -U __brew_prefix ($__brew --prefix)
     end
 end
 

--- a/tilde/.config/fish/conf.d/fzf_env.fish
+++ b/tilde/.config/fish/conf.d/fzf_env.fish
@@ -1,27 +1,32 @@
-if status --is-interactive
-    set -l base03 234
-    set -l base02 235
-    set -l base01 240
-    set -l base00 241
-    set -l base0 244
-    set -l base1 245
-    set -l base2 254
-    set -l base3 230
-    set -l yellow 136
-    set -l orange 166
-    set -l red 160
-    set -l magenta 125
-    set -l violet 61
-    set -l blue 33
-    set -l cyan 37
-    set -l green 64
+status --is-interactive
+or exit 0
 
-    # Solarized Dark color scheme for fzf
-    set -gx FZF_DEFAULT_OPTS "--height 40% --reverse --border --inline-info --color fg:-1,bg:-1,hl:$blue,fg+:$base2,hl+:$blue --color info:$yellow,prompt:$yellow,pointer:$base3,marker:$base3,spinner:$yellow"
+set -l color00 '#002b36'
+set -l color01 '#073642'
+set -l color02 '#586e75'
+set -l color03 '#657b83'
+set -l color04 '#839496'
+set -l color05 '#93a1a1'
+set -l color06 '#eee8d5'
+set -l color07 '#fdf6e3'
+set -l color08 '#dc322f'
+set -l color09 '#cb4b16'
+set -l color0A '#b58900'
+set -l color0B '#859900'
+set -l color0C '#2aa198'
+set -l color0D '#268bd2'
+set -l color0E '#6c71c4'
+set -l color0F '#d33682'
 
-    # Add in a preview window when using C-t to search for files.
-    set -gx FZF_CTRL_T_OPTS "--preview-window right:60% --preview='bat --color=always --style=numbers --line-range=:500 {}' "
 
-    set -gx FZF_DEFAULT_COMMAND 'rg --files --no-messages --no-ignore --hidden --follow --glob "!.git/*"'
-    set -gx FZF_CTRL_T_COMMAND "command find -L \$dir -type f 2> /dev/null | sed '1d; s#^\./##'"
-end
+# Solarized Dark color scheme for fzf
+set -gx FZF_DEFAULT_OPTS "--height 40% --reverse --border --inline-info"\
+" --color=bg+:$color01,bg:$color00,spinner:$color0C,hl:$color0D"\
+" --color=fg:$color04,header:$color0D,info:$color0A,pointer:$color0C"\
+" --color=marker:$color0C,fg+:$color06,prompt:$color0A,hl+:$color0D"
+
+# Add in a preview window when using C-t to search for files.
+set -gx FZF_CTRL_T_OPTS "--preview-window right:60% --preview='bat --color=always --style=numbers --line-range=:500 {}' "
+
+set -gx FZF_DEFAULT_COMMAND 'rg --files --no-messages --no-ignore --hidden --follow --glob "!.git/*"'
+set -gx FZF_CTRL_T_COMMAND "command find -L \$dir -type f 2> /dev/null | sed '1d; s#^\./##'"

--- a/tilde/.config/fish/conf.d/pyenv.fish
+++ b/tilde/.config/fish/conf.d/pyenv.fish
@@ -1,3 +1,6 @@
+status --is-interactive
+or exit 0
+
 set -Ux PYENV_ROOT $HOME/.pyenv
 fish_add_path $PYENV_ROOT/bin
 

--- a/tilde/.config/fish/event_handlers/__fish_dirchanged_update_file_list.fish
+++ b/tilde/.config/fish/event_handlers/__fish_dirchanged_update_file_list.fish
@@ -1,3 +1,3 @@
-function __fish_dirchanged_update_file_list --on-event dirchanged --description "Update the current file list on a directory change"
+function __fish_dirchanged_update_file_list --on-variable PWD --description "Update the current file list on a directory change"
     set -g __dir_file_list (command ls -1a)
 end

--- a/tilde/.config/fish/shims/cd.fish
+++ b/tilde/.config/fish/shims/cd.fish
@@ -1,4 +1,0 @@
-function cd --wraps cd -d 'Emmit the dirchanged signal'
-    builtin cd $argv
-    emit dirchanged
-end


### PR DESCRIPTION
- Cribbing `status --is-interactive` checks from async.fish
- Fixed setting the brew path
- Fixing FZF theming to be cleaner
- Using `--on-variable PWD` for __fish_dirchanged_update_file_list instead of using a shim for `cd` and emitting an event.